### PR TITLE
Add optional stream parameter to answerQuestionFromChat method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,9 +69,9 @@
         "fix-lint": "pint -v --repair",
         "refactor": "rector --debug",
         "test:lint": "pint --test -v",
-        "test:refactor": "rector --dry-run",
-        "test:types": "phpstan analyse --ansi",
-        "test:type-coverage": "pest ./tests --type-coverage --min=100",
+        "test:refactor": "rector --dry-run ",
+        "test:types": "phpstan analyse --ansi --memory-limit 4G",
+        "test:type-coverage": "php ./vendor/bin/pest ./tests --type-coverage --min=100 --memory-limit=4G",
         "test:unit": "pest ./tests/Unit --colors=always",
         "test:int": "pest ./tests/Integration --colors=always",
         "test": [

--- a/src/Query/SemanticSearch/QuestionAnswering.php
+++ b/src/Query/SemanticSearch/QuestionAnswering.php
@@ -47,8 +47,10 @@ class QuestionAnswering
     }
 
     /**
-     * @param  Message[]  $messages
-     * @param  array<string, string|int>|array<mixed[]>  $additionalArguments
+     * @param Message[] $messages
+     * @param int $k
+     * @param array<string, string|int>|array<mixed[]> $additionalArguments
+     * @param bool $stream
      */
     public function answerQuestionFromChat(array $messages, int $k = 4, array $additionalArguments = [], bool $stream = true): string | StreamInterface
     {

--- a/src/Query/SemanticSearch/QuestionAnswering.php
+++ b/src/Query/SemanticSearch/QuestionAnswering.php
@@ -47,12 +47,10 @@ class QuestionAnswering
     }
 
     /**
-     * @param Message[] $messages
-     * @param int $k
-     * @param array<string, string|int>|array<mixed[]> $additionalArguments
-     * @param bool $stream
+     * @param  Message[]  $messages
+     * @param  array<string, string|int>|array<mixed[]>  $additionalArguments
      */
-    public function answerQuestionFromChat(array $messages, int $k = 4, array $additionalArguments = [], bool $stream = true): string | StreamInterface
+    public function answerQuestionFromChat(array $messages, int $k = 4, array $additionalArguments = [], bool $stream = true): string|StreamInterface
     {
         // First we need to give the context to openAI with the good instructions
         $userQuestion = $messages[count($messages) - 1]->content;
@@ -61,7 +59,7 @@ class QuestionAnswering
 
         // Then we can just give the conversation
 
-        if($stream) {
+        if ($stream) {
             return $this->chat->generateChatStream($messages);
         }
 

--- a/src/Query/SemanticSearch/QuestionAnswering.php
+++ b/src/Query/SemanticSearch/QuestionAnswering.php
@@ -50,7 +50,7 @@ class QuestionAnswering
      * @param  Message[]  $messages
      * @param  array<string, string|int>|array<mixed[]>  $additionalArguments
      */
-    public function answerQuestionFromChat(array $messages, int $k = 4, array $additionalArguments = []): StreamInterface
+    public function answerQuestionFromChat(array $messages, int $k = 4, array $additionalArguments = [], bool $stream = true): string | StreamInterface
     {
         // First we need to give the context to openAI with the good instructions
         $userQuestion = $messages[count($messages) - 1]->content;
@@ -58,7 +58,12 @@ class QuestionAnswering
         $this->chat->setSystemMessage($systemMessage);
 
         // Then we can just give the conversation
-        return $this->chat->generateChatStream($messages);
+
+        if($stream) {
+            return $this->chat->generateChatStream($messages);
+        }
+
+        return $this->chat->generateChat($messages);
     }
 
     /**


### PR DESCRIPTION
Hi! Today, I encountered a situation where I needed to use the answerQuestionFromChat method in QuestionAnswering but without streaming, which was not currently supported.

This PR introduces a new optional $stream parameter to the answerQuestionFromChat method. This parameter allows greater flexibility by enabling the method to return either a streaming response or a direct response. The $stream parameter defaults to true, ensuring backward compatibility with existing code.

Please let me know if there are any changes or improvements you’d like me to make.