### PR TITLE
fix: make the `decodeStreamOfText` and `decodeStreamOfChat` methods s…

### DIFF
--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -271,8 +271,8 @@ class OllamaChat implements ChatInterface
     protected function decodeStreamOfText(ResponseInterface $response): StreamInterface
     {
         // Split the application/x-ndjson response into json responses
-        $generator = function(ResponseInterface $response) {
-            while (!$response->getBody()->eof()) {
+        $generator = function (ResponseInterface $response) {
+            while (! $response->getBody()->eof()) {
                 $line = $this->readLineFromStream($response->getBody());
 
                 if (empty($line)) {
@@ -300,7 +300,7 @@ class OllamaChat implements ChatInterface
     {
         $buffer = '';
 
-        while (!$stream->eof()) {
+        while (! $stream->eof()) {
             if ('' === ($byte = $stream->read(1))) {
                 return $buffer;
             }
@@ -318,8 +318,8 @@ class OllamaChat implements ChatInterface
      */
     protected function decodeStreamOfChat(ResponseInterface $response): StreamInterface
     {
-        $generator = function(ResponseInterface $response) {
-            while (!$response->getBody()->eof()) {
+        $generator = function (ResponseInterface $response) {
+            while (! $response->getBody()->eof()) {
                 $line = $this->readLineFromStream($response->getBody());
 
                 if (empty($line)) {

--- a/src/Chat/OllamaChat.php
+++ b/src/Chat/OllamaChat.php
@@ -63,7 +63,7 @@ class OllamaChat implements ChatInterface
      */
     public function generateText(string $prompt): string
     {
-        $params = $params = [
+        $params = [
             ...$this->modelOptions,
             'model' => $this->config->model,
             'prompt' => $prompt,
@@ -252,7 +252,7 @@ class OllamaChat implements ChatInterface
      */
     protected function sendRequest(string $method, string $path, array $json): ResponseInterface
     {
-        $response = $this->client->request($method, $path, ['json' => $json]);
+        $response = $this->client->request($method, $path, ['json' => $json, 'stream' => $json['stream'] ?? false]);
         $status = $response->getStatusCode();
         if ($status < 200 || $status >= 300) {
             throw new HttpException(sprintf(
@@ -271,10 +271,15 @@ class OllamaChat implements ChatInterface
     protected function decodeStreamOfText(ResponseInterface $response): StreamInterface
     {
         // Split the application/x-ndjson response into json responses
-        $stream = explode("\n", $response->getBody()->getContents());
-        $generator = function (array $stream) {
-            foreach ($stream as $partialResponse) {
-                $json = Utility::decodeJson($partialResponse);
+        $generator = function(ResponseInterface $response) {
+            while (!$response->getBody()->eof()) {
+                $line = $this->readLineFromStream($response->getBody());
+
+                if (empty($line)) {
+                    continue;
+                }
+
+                $json = Utility::decodeJson($line);
                 if ((bool) $json['done']) {
                     break;
                 }
@@ -288,7 +293,24 @@ class OllamaChat implements ChatInterface
             }
         };
 
-        return Utils::streamFor($generator($stream));
+        return Utils::streamFor($generator($response));
+    }
+
+    private function readLineFromStream(StreamInterface $stream): string
+    {
+        $buffer = '';
+
+        while (!$stream->eof()) {
+            if ('' === ($byte = $stream->read(1))) {
+                return $buffer;
+            }
+            $buffer .= $byte;
+            if ($byte === "\n") {
+                break;
+            }
+        }
+
+        return $buffer;
     }
 
     /**
@@ -296,11 +318,15 @@ class OllamaChat implements ChatInterface
      */
     protected function decodeStreamOfChat(ResponseInterface $response): StreamInterface
     {
-        // Split the application/x-ndjson response into json responses
-        $stream = explode("\n", $response->getBody()->getContents());
-        $generator = function (array $stream) {
-            foreach ($stream as $partialResponse) {
-                $json = Utility::decodeJson($partialResponse);
+        $generator = function(ResponseInterface $response) {
+            while (!$response->getBody()->eof()) {
+                $line = $this->readLineFromStream($response->getBody());
+
+                if (empty($line)) {
+                    continue;
+                }
+
+                $json = Utility::decodeJson($line);
                 if ((bool) $json['done']) {
                     break;
                 }
@@ -314,7 +340,7 @@ class OllamaChat implements ChatInterface
             }
         };
 
-        return Utils::streamFor($generator($stream));
+        return Utils::streamFor($generator($response));
     }
 
     /**


### PR DESCRIPTION
…treaming again. Instad of waiting for the whole response to be in the buffer, we start to parse the contents as soon as received by guzzle.

This should close https://github.com/LLPhant/LLPhant/issues/176 was well
closes #176 