### PR TITLE
Allow to pass a logger to Chat instances to debug all LLM calls easily

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "openai-php/client": "^v0.10.3",
         "phpoffice/phpword": "^1.3.0",
         "psr/http-message": "^2.0",
+        "psr/log": "^3.0",
         "smalot/pdfparser": "^2.11"
     },
     "suggest": {

--- a/src/Chat/AnthropicChat.php
+++ b/src/Chat/AnthropicChat.php
@@ -14,12 +14,16 @@ use LLPhant\Exception\HttpException;
 use LLPhant\Utility;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class AnthropicChat implements ChatInterface
 {
     private const DEFAULT_URL = 'https://api.anthropic.com';
 
     private const CURRENT_VERSION = '2023-06-01';
+
+    private readonly LoggerInterface $logger;
 
     private ?Message $systemMessage = null;
 
@@ -41,11 +45,12 @@ class AnthropicChat implements ChatInterface
 
     use AnthropicTotalTokensTrait;
 
-    public function __construct(AnthropicConfig $config = new AnthropicConfig())
+    public function __construct(AnthropicConfig $config = new AnthropicConfig(), ?LoggerInterface $logger = null)
     {
         $this->modelOptions = $config->modelOptions;
         $this->model = $config->model;
         $this->maxTokens = $config->maxTokens;
+        $this->logger = $logger ?: new NullLogger();
 
         if ($config->client instanceof Client) {
             $this->client = $config->client;
@@ -198,6 +203,11 @@ class AnthropicChat implements ChatInterface
      */
     protected function sendRequest(array $json, bool $stream): ResponseInterface
     {
+        $this->logger->debug('Calling POST v1/messages', [
+            'chat' => self::class,
+            'params' => $json,
+        ]);
+
         $response = $this->client->request('POST', 'v1/messages', ['stream' => $stream, 'json' => $json]);
         $status = $response->getStatusCode();
         if ($status < 200 || $status >= 300) {

--- a/src/Chat/GPT4Turbo.php
+++ b/src/Chat/GPT4Turbo.php
@@ -4,15 +4,16 @@ namespace LLPhant\Chat;
 
 use LLPhant\Chat\Enums\OpenAIChatModel;
 use LLPhant\OpenAIConfig;
+use Psr\Log\LoggerInterface;
 
 class GPT4Turbo extends OpenAIChat
 {
     /**
      * @throws \Exception
      */
-    public function __construct(?OpenAIConfig $config = null)
+    public function __construct(?OpenAIConfig $config = null, ?LoggerInterface $logger = null)
     {
-        parent::__construct($config);
+        parent::__construct($config, $logger);
         $this->model = $config->model ?? OpenAIChatModel::Gpt4Turbo->value;
     }
 }

--- a/src/Chat/MistralAIChat.php
+++ b/src/Chat/MistralAIChat.php
@@ -7,6 +7,7 @@ use LLPhant\Chat\Enums\MistralAIChatModel;
 use LLPhant\OpenAIConfig;
 use OpenAI\Client;
 use OpenAI\Factory;
+use Psr\Log\LoggerInterface;
 
 use function getenv;
 
@@ -14,7 +15,7 @@ class MistralAIChat extends OpenAIChat
 {
     private const BASE_URL = 'api.mistral.ai/v1';
 
-    public function __construct(?OpenAIConfig $config = null)
+    public function __construct(?OpenAIConfig $config = null, ?LoggerInterface $logger = null)
     {
         if (! $config instanceof OpenAIConfig) {
             $config = new OpenAIConfig();
@@ -34,6 +35,6 @@ class MistralAIChat extends OpenAIChat
         }
 
         $config->model ??= MistralAIChatModel::large->value;
-        parent::__construct($config);
+        parent::__construct($config, $logger);
     }
 }

--- a/tests/Unit/Chat/MistralAIChatTest.php
+++ b/tests/Unit/Chat/MistralAIChatTest.php
@@ -10,6 +10,7 @@ use Mockery;
 use OpenAI\Client;
 use OpenAI\Contracts\TransporterContract;
 use Psr\Http\Message\StreamInterface;
+use Psr\Log\AbstractLogger;
 
 it('no error when construct with no model', function () {
     $config = new OpenAIConfig();
@@ -19,6 +20,16 @@ it('no error when construct with no model', function () {
 });
 
 it('returns a stream response using generateStreamOfText()', function () {
+    $logger = new class extends AbstractLogger
+    {
+        public array $logs = [];
+
+        public function log($level, string|\Stringable $message, array $context = []): void
+        {
+            $this->logs[] = ['level' => $level, 'message' => $message, 'context' => $context];
+        }
+    };
+
     $response = new Response(
         200,
         [],
@@ -31,10 +42,13 @@ it('returns a stream response using generateStreamOfText()', function () {
 
     $config = new OpenAIConfig();
     $config->client = new Client($transport);
-    $chat = new MistralAIChat($config);
+    $chat = new MistralAIChat($config, $logger);
 
     $response = $chat->generateStreamOfText('this is the prompt question');
     expect($response)->toBeInstanceof(StreamInterface::class);
+    expect($logger->logs)->toHaveCount(1);
+    expect(array_map(fn ($l) => $l['message'], $logger->logs))->toBe(['Calling Chat::createStreamed']);
+    expect(array_map(fn ($l) => $l['level'], $logger->logs))->toBe(['debug']);
 });
 
 it('returns a stream response using generateChatStream()', function () {


### PR DESCRIPTION
When working in a Symfony environment, especially with the QuestionAnswering class and MultiQuery transformer, I realized I was wondering what LLM calls were done internally, and I didn't have an easy way to see them for debugging.

Thus this PR proposes to introduce a logger as an optional argument of ChatInterface classes, to expose the behavior happening internally to LLPhant.

I focused on ChatInterface implementations for now but the same could probably be done for images/vision/audio.