### PR TITLE
log args sent to openai

### DIFF
--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -31,6 +31,9 @@ class OpenAIChat implements ChatInterface
 
     public string $model;
 
+    /** @var array<string, mixed>[] Permits to easily debug all the messages sent toward OpenAi lib */
+    public array $argsLog = [];
+
     private ?CreateResponse $lastResponse = null;
 
     private int $totalTokens = 0;
@@ -315,6 +318,7 @@ class OpenAIChat implements ChatInterface
             $openAiArgs['tool_choice'] = ToolFormatter::formatToolChoice($this->requiredFunction);
         }
 
+        $this->argsLog[] = $openAiArgs;
         return $openAiArgs;
     }
 

--- a/src/Chat/OpenAIChat.php
+++ b/src/Chat/OpenAIChat.php
@@ -319,6 +319,7 @@ class OpenAIChat implements ChatInterface
         }
 
         $this->argsLog[] = $openAiArgs;
+
         return $openAiArgs;
     }
 


### PR DESCRIPTION
Related to #301

I finally prefered to expose all messages sent via OpenAi sdk.

Could not be generalized to other LLM because we are sending params (but an equivalent could be done with logParams).