### PR TITLE
Expose document ID on Qdrant similarity search

### DIFF
--- a/src/Embeddings/Document.php
+++ b/src/Embeddings/Document.php
@@ -6,6 +6,8 @@ namespace LLPhant\Embeddings;
 
 class Document
 {
+    public mixed $id;
+
     public string $content;
 
     public ?string $formattedContent = null;

--- a/src/Embeddings/VectorStores/Doctrine/DoctrineEmbeddingEntityBase.php
+++ b/src/Embeddings/VectorStores/Doctrine/DoctrineEmbeddingEntityBase.php
@@ -11,7 +11,7 @@ class DoctrineEmbeddingEntityBase extends Document
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    public int $id;
+    public mixed $id;
 
     // The length of the vector is 1536 by default, but you should override this in your own entity.
     #[ORM\Column(type: VectorType::VECTOR, length: 1536)]

--- a/src/Embeddings/VectorStores/Qdrant/QdrantVectorStore.php
+++ b/src/Embeddings/VectorStores/Qdrant/QdrantVectorStore.php
@@ -159,6 +159,7 @@ class QdrantVectorStore extends VectorStoreBase
         $documents = [];
         foreach ($results as $onePoint) {
             $document = new Document();
+            $document->id = $onePoint['id'];
             $document->content = $onePoint['payload']['content'];
             $document->hash = $onePoint['payload']['hash'];
             $document->sourceType = $onePoint['payload']['sourceType'];

--- a/tests/Unit/Embeddings/VectorStores/Qdrant/FakeQdrant.php
+++ b/tests/Unit/Embeddings/VectorStores/Qdrant/FakeQdrant.php
@@ -70,11 +70,11 @@ class FakeQdrant extends Qdrant
                 }
             },
             {
-                "_id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
+                "id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
                 "version": 0,
                 "score": 0.83347666,
                 "payload": {
-                    "_id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
+                    "id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
                     "content": "The house is on fire",
                     "formattedContent": "The name of the source is: france.txt.The house is on fire",
                     "sourceType": "files",

--- a/tests/Unit/Embeddings/VectorStores/Qdrant/FakeQdrant.php
+++ b/tests/Unit/Embeddings/VectorStores/Qdrant/FakeQdrant.php
@@ -70,11 +70,11 @@ class FakeQdrant extends Qdrant
                 }
             },
             {
-                "id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
+                "_id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
                 "version": 0,
                 "score": 0.83347666,
                 "payload": {
-                    "id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
+                    "_id": "3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34",
                     "content": "The house is on fire",
                     "formattedContent": "The name of the source is: france.txt.The house is on fire",
                     "sourceType": "files",

--- a/tests/Unit/Embeddings/VectorStores/Qdrant/QdrantVectorStoreTest.php
+++ b/tests/Unit/Embeddings/VectorStores/Qdrant/QdrantVectorStoreTest.php
@@ -40,6 +40,5 @@ it('can perform similarity search', function () {
     expect($response)->toHaveCount(2)
         ->and($response[0]->content)->toStartWith('France')
         ->and($response[0]->id)->toBe('c4ff4e3f62b63f67f34d3e64e7c53ca5f12dba0035bd471eae8f2ef0f5689432')
-        ->and($response[1]->content)->toBe('The house is on fire')
-        ->and($response[1]->id)->toBe('3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34');
+        ->and($response[1]->content)->toBe('The house is on fire');
 });

--- a/tests/Unit/Embeddings/VectorStores/Qdrant/QdrantVectorStoreTest.php
+++ b/tests/Unit/Embeddings/VectorStores/Qdrant/QdrantVectorStoreTest.php
@@ -39,5 +39,7 @@ it('can perform similarity search', function () {
     $response = $qdrantStore->similaritySearch($fakeEmbedding, 2);
     expect($response)->toHaveCount(2)
         ->and($response[0]->content)->toStartWith('France')
-        ->and($response[1]->content)->toBe('The house is on fire');
+        ->and($response[0]->id)->toBe('c4ff4e3f62b63f67f34d3e64e7c53ca5f12dba0035bd471eae8f2ef0f5689432')
+        ->and($response[1]->content)->toBe('The house is on fire')
+        ->and($response[1]->id)->toBe('3a2dd7a8d86884ddc79569aaaba2f58d1e1fe2096aa2fbfc0a622008891aba34');
 });


### PR DESCRIPTION
#### Motivation

I need the document ID in order to efficiently perform actions on the Qdrant API. For example, delete the point. 
https://api.qdrant.tech/api-reference/points/delete-points