### PR TITLE
fix(anthropic): Rely on Guzzle\ClientInterface instead of the implementation

### DIFF
--- a/src/AnthropicConfig.php
+++ b/src/AnthropicConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LLPhant;
 
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 
 class AnthropicConfig
 {
@@ -26,7 +26,7 @@ class AnthropicConfig
         public readonly int $maxTokens = 1024,
         public readonly array $modelOptions = [],
         public readonly ?string $apiKey = null,
-        public readonly ?Client $client = null, )
+        public readonly ?ClientInterface $client = null, )
     {
     }
 }

--- a/src/Chat/AnthropicChat.php
+++ b/src/Chat/AnthropicChat.php
@@ -3,6 +3,7 @@
 namespace LLPhant\Chat;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Utils;
 use LLPhant\AnthropicConfig;
 use LLPhant\Chat\Anthropic\AnthropicMessage;
@@ -30,7 +31,7 @@ class AnthropicChat implements ChatInterface
     /** @var array<string, mixed> */
     private array $modelOptions = [];
 
-    public Client $client;
+    public ClientInterface $client;
 
     private readonly string $model;
 
@@ -52,7 +53,7 @@ class AnthropicChat implements ChatInterface
         $this->maxTokens = $config->maxTokens;
         $this->logger = $logger ?: new NullLogger();
 
-        if ($config->client instanceof Client) {
+        if ($config->client instanceof ClientInterface) {
             $this->client = $config->client;
         } else {
             $this->client = new Client([


### PR DESCRIPTION
It allows to use another compatible client (like https://github.com/symfony/symfony/blob/7.3/src/Symfony/Component/HttpClient/Psr18Client.php).

I don't have the use case for other providers, only for Anthropic. Let me know if I can adapt this for other providers.