### PR TITLE
Add tools to Mistral

### DIFF
--- a/src/Chat/FunctionInfo/ToolCall.php
+++ b/src/Chat/FunctionInfo/ToolCall.php
@@ -11,7 +11,7 @@ class ToolCall
 
     public readonly string $type;
 
-    public function __construct(public readonly string $id, string $name, public readonly string $jsonArgs)
+    public function __construct(public readonly string $id, string $name, string $jsonArgs)
     {
         $this->type = 'function';
         $this->function = ['name' => $name, 'arguments' => $jsonArgs];

--- a/src/Chat/FunctionInfo/ToolFormatter.php
+++ b/src/Chat/FunctionInfo/ToolFormatter.php
@@ -41,6 +41,7 @@ class ToolFormatter
                 'function' => [
                     'name' => $functionInfo->name,
                     'description' => $functionInfo->description,
+                    'parameters' => new \stdClass(),
                 ],
             ];
         }


### PR DESCRIPTION
Trying to fix https://github.com/LLPhant/LLPhant/issues/311 by adding support for tools with Mistral, but can't make it work with the current OpenAI client :cry: 

This PR introduces an integration test for Mistral tools and addresses two issues that I think _should_ be safe for OpenAI, but I'm unsure since I couldn't run integration tests for OpenAI chat. However, one issue persists because the Mistral API does not return the correct type attribute, which the OpenAI client requires.

Editing the vendor class resolves the issue (see diff below), but I'm unsure how to properly address it. Should we consider using another PHP client for Mistral?

```diff
--- a/vendor/openai-php/client/src/Responses/Chat/CreateResponseToolCall.php
--- b/vendor/openai-php/client/src/Responses/Chat/CreateResponseToolCall.php
@@ -19,7 +19,7 @@ final class CreateResponseToolCall
     {
         return new self(
             $attributes['id'],
-            $attributes['type'],
+            $attributes['type'] ?? 'function',
             CreateResponseToolCallFunction::from($attributes['function']),
         );
     }
```