### PR TITLE
Update OpenAI client to v0.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.1.0",
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.7",
-        "openai-php/client": "^v0.10.3",
+        "openai-php/client": "^v0.13.0",
         "phpoffice/phpword": "^1.3.0",
         "psr/http-message": "^2.0",
         "psr/log": "^3.0",

--- a/tests/Unit/Chat/MockOpenAIClient.php
+++ b/tests/Unit/Chat/MockOpenAIClient.php
@@ -16,6 +16,7 @@ use OpenAI\Contracts\Resources\FineTuningContract;
 use OpenAI\Contracts\Resources\ImagesContract;
 use OpenAI\Contracts\Resources\ModelsContract;
 use OpenAI\Contracts\Resources\ModerationsContract;
+use OpenAI\Contracts\Resources\ResponsesContract;
 use OpenAI\Contracts\Resources\ThreadsContract;
 use OpenAI\Contracts\Resources\VectorStoresContract;
 
@@ -29,6 +30,11 @@ class MockOpenAIClient implements ClientContract
     public function chat(): ChatContract
     {
         return new MockOpenAIChat();
+    }
+
+    public function responses(): ResponsesContract
+    {
+        // TODO: Implement responses() method.
     }
 
     public function embeddings(): EmbeddingsContract

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -211,13 +211,13 @@ it('does not throw away "0" strings when creating streamed response', function (
     $response->allows([
         'getBody' => $stream,
     ]);
-    $response->shouldReceive('getStatusCode')->andReturn(200);
+    $response->shouldReceive('getHeaders');
 
     $transport = Mockery::mock(TransporterContract::class);
     $transport->allows([
         'requestStream' => $response,
     ]);
-    $transport->shouldReceive('requestObject')->andReturn($response);
+    $transport->shouldReceive('requestObject');
 
     $config = new OpenAIConfig();
     $config->client = new Client($transport);

--- a/tests/Unit/Chat/OpenAIChatTest.php
+++ b/tests/Unit/Chat/OpenAIChatTest.php
@@ -211,11 +211,13 @@ it('does not throw away "0" strings when creating streamed response', function (
     $response->allows([
         'getBody' => $stream,
     ]);
+    $response->shouldReceive('getStatusCode')->andReturn(200);
 
     $transport = Mockery::mock(TransporterContract::class);
     $transport->allows([
         'requestStream' => $response,
     ]);
+    $transport->shouldReceive('requestObject')->andReturn($response);
 
     $config = new OpenAIConfig();
     $config->client = new Client($transport);


### PR DESCRIPTION
I am not able to run the pest tests:

<img width="866" alt="Screenshot 2025-05-17 at 11 16 42 AM" src="https://github.com/user-attachments/assets/3b702ccd-048d-456d-ac2e-599bc22e6688" />

My application requires access to the OpenAI Responses endpoint, which is not available in v0.10.3 of the OpenAI client, on which LLPhant currently depends.

For what it's worth, all my other applications of LLPhant Chat are working fine at v0.13.