### PR TITLE
feat(http-interop): Install abstract dependencies to prepare Guzzle replacement with HTTP client abstractions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
         "guzzlehttp/psr7": "^2.7",
         "openai-php/client": "^v0.13.0",
         "phpoffice/phpword": "^1.4.0",
+        "php-http/discovery": "^1.20.0",
+        "php-http/multipart-stream-builder": "^1.4.2",
+        "psr/http-client": "^1.0.3",
         "psr/http-message": "^2.0",
         "psr/log": "^3.0",
         "smalot/pdfparser": "^2.11"


### PR DESCRIPTION
Ref: https://github.com/LLPhant/LLPhant/issues/338

This PR aims to prepare the ground for https://github.com/LLPhant/LLPhant/pull/341 and next PRs to replace hard references to Guzzle with HTTP client abstractions (client and factories).

If you agree to merge this one, nothing will change for now on `main` branch, but it will allow contributors to leverage those abstraction to replace step-by-step Guzzle references in every part of the library. A first list of locations to work on is available here https://github.com/LLPhant/LLPhant/pull/341

Thanks 🙏 