### PR TITLE
Xml format evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,7 @@ Strategies for evaluating LLM responses include:
 - Trajectory evaluator
 - Pairwise string comparison (A/B testing)
 - JSON format validator
+- XML format validator
 - Avoid fallback message
 
 Choose most relevant evaluation strategy for your use case and run one of methods listed below. 
@@ -1132,7 +1133,7 @@ scores:
 ```json
 {
     "score": 1,
-    "error": "" //parsing error message if invalid
+    "error": ""
 }
 ```
 
@@ -1150,7 +1151,7 @@ scores:
 ```json
 {
     "score" : 0,         
-    "detectedIndicator" : "I'm sorry" // first matched phrase
+    "detectedIndicator" : "I'm sorry"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1161,7 +1161,7 @@ After each model response they run an evaluator of your choice (e.g. JSON‐synt
 Based on the result, either pass the answer through, retry the call, block it, or route it to a custom callback.
 
 ```php
-    $llm = getChatMock();
+    $llm = new OpenAIChat();
 
     $guardrails = new Guardrails(
         llm: $llm,
@@ -1169,7 +1169,7 @@ Based on the result, either pass the answer through, retry the call, block it, o
         strategy: Guardrails::STRATEGY_RETRY,
     );
 
-    $response = $guardrails->generateText('some prompt message');
+    $response = $guardrails->generateText('generate answer in JSON format with object that consists of "correctKey" as a key and "correctVal" as a value');
 ```
 
 result without retry:

--- a/src/Evaluation/Output/XMLFormatEvaluator.php
+++ b/src/Evaluation/Output/XMLFormatEvaluator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace LLPhant\Evaluation\Output;
+
+use DOMDocument;
+use LLPhant\Evaluation\AbstractEvaluator;
+use LLPhant\Evaluation\EvaluationResults;
+
+class XMLFormatEvaluator extends AbstractEvaluator
+{
+    public function evaluateText(string $candidate, string $reference = '', int $n = 1): EvaluationResults
+    {
+        if ($reference !== '') {
+            throw new \LogicException('XML format evaluator takes only output text as argument');
+        }
+        if ($n !== 1) {
+            throw new \LogicException("XML format evaluator doesn't support N-grams");
+        }
+
+        libxml_use_internal_errors(true);
+
+        $dom = new DOMDocument();
+        $isValidXML = (bool) $dom->loadXML($candidate, LIBXML_NOENT | LIBXML_NONET);
+
+        $errors = libxml_get_errors();
+        libxml_clear_errors();
+        libxml_use_internal_errors(false);
+
+        return new EvaluationResults(
+            'XML valid format evaluator',
+            [
+                'score' => (int) $isValidXML,
+                'error' => $errors !== [] ? json_encode($errors, JSON_THROW_ON_ERROR) : '',
+            ]
+        );
+    }
+
+    public function evaluateMessages(array $messages, array $references = [], int $n = 1): EvaluationResults
+    {
+        if ($references !== []) {
+            throw new \LogicException('XML format evaluator takes only output texts as argument');
+        }
+        if ($n !== 1) {
+            throw new \LogicException("XML format evaluator doesn't support N-grams");
+        }
+        $filteredMessages = $this->filterAssistantMessages($messages);
+        $resultsAll = [];
+        foreach ($filteredMessages as $filteredMessage) {
+            $resultsSingle = $this->evaluateText($filteredMessage);
+            $resultsAll[] = $resultsSingle->getResults()['score'];
+        }
+
+        return new EvaluationResults(
+            'XML valid format evaluator',
+            $resultsAll
+        );
+    }
+}

--- a/src/Evaluation/README.md
+++ b/src/Evaluation/README.md
@@ -23,6 +23,7 @@ There are multiple strategies included for evaluating LLM responses:
 - Trajectory evaluator
 - Pairwise string comparison (A/B testing)
 - JSON format validator
+- XML format validator
 - Avoid fallback messages
 
 ### Criteria evaluator
@@ -310,7 +311,25 @@ scores:
 ```json
 {
     "score": 1,
-    "error": "" //parsing error message if invalid
+    "error": ""
+}
+```
+
+#### XML format validator
+```php
+$candidate = '<sometag>some content</sometag>';
+
+$evaluator = new XMLFormatEvaluator();
+$results = $evaluator->evaluateText($candidate);
+$scores = $results->getResults();
+```
+
+scores:
+
+```json
+{
+    "score": 1,
+    "error": ""
 }
 ```
 
@@ -328,7 +347,7 @@ scores:
 ```json
 {
     "score" : 0,         
-    "detectedIndicator" : "I'm sorry" // first matched phrase
+    "detectedIndicator" : "I'm sorry"
 }
 ```
 

--- a/src/Evaluation/README.md
+++ b/src/Evaluation/README.md
@@ -339,7 +339,7 @@ After each model response they run an evaluator of your choice (e.g. JSON‐synt
 Based on the result, either pass the answer through, retry the call, block it, or route it to a custom callback.
 
 ```php
-    $llm = getChatMock();
+    $llm = new OpenAIChat();
 
     $guardrails = new Guardrails(
         llm: $llm,
@@ -347,7 +347,7 @@ Based on the result, either pass the answer through, retry the call, block it, o
         strategy: Guardrails::STRATEGY_RETRY,
     );
 
-    $response = $guardrails->generateText('some prompt message');
+    $response = $guardrails->generateText('generate answer in JSON format with object that consists of "correctKey" as a key and "correctVal" as a value');
 ```
 
 result without retry:

--- a/tests/Unit/Evaluation/Output/XMLFormatEvaluatorTest.php
+++ b/tests/Unit/Evaluation/Output/XMLFormatEvaluatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Evaluation\StringComparison;
+
+use LLPhant\Evaluation\Output\XMLFormatEvaluator;
+
+it('can evaluate valid XML response', function (): void {
+    $output = '<sometag>some content</sometag>';
+
+    $results = (new XMLFormatEvaluator())->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 1,
+        'error' => '',
+    ]);
+});
+
+it('can evaluate invalid XML response', function (): void {
+    $output = '<sometag>some content and missing closing tag';
+
+    $results = (new XMLFormatEvaluator())->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 0,
+        'error' => '[{"level":3,"code":77,"column":46,"message":"Premature end of data in tag sometag line 1\n","file":"","line":1}]',
+    ]);
+});
+
+it('can evaluate valid XML response with unexpected text before', function (): void {
+    $output = 'Here is XML output: <sometag>some content</sometag>';
+
+    $results = (new XMLFormatEvaluator())->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 0,
+        'error' => '[{"level":3,"code":4,"column":1,"message":"Start tag expected, \'<\' not found\n","file":"","line":1}]',
+    ]);
+});


### PR DESCRIPTION
Introduce XML format evaluator.
It is another LLM output evaluator, similar to previously added JSON format evaluator.
It can be used as standalone evaluator, keeping same interface or passed to Guardrails. 