### PR TITLE
introduce Token limit evaluator and word limit evaluator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,14 @@
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.7",
         "openai-php/client": "^v0.13.0",
-        "phpoffice/phpword": "^1.4.0",
         "php-http/discovery": "^1.20.0",
         "php-http/multipart-stream-builder": "^1.4.2",
+        "phpoffice/phpword": "^1.4.0",
         "psr/http-client": "^1.0.3",
         "psr/http-message": "^2.0",
         "psr/log": "^3.0",
-        "smalot/pdfparser": "^2.11"
+        "smalot/pdfparser": "^2.11",
+        "yethee/tiktoken": "^0.10.0"
     },
     "suggest": {
         "doctrine/orm": "This is required for the DoctrineVectoreStore. This should be working with any version ^2.13.0",

--- a/src/Evaluation/Output/TokenLimitEvaluator.php
+++ b/src/Evaluation/Output/TokenLimitEvaluator.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace LLPhant\Evaluation\Output;
+
+use LLPhant\Evaluation\AbstractEvaluator;
+use LLPhant\Evaluation\EvaluationResults;
+use Yethee\Tiktoken\EncoderProvider;
+
+class TokenLimitEvaluator extends AbstractEvaluator
+{
+    private string $provider = 'cl100k_base';
+
+    private int $tokenLimit = 0;
+
+    public function evaluateText(string $candidate, string $reference = '', int $n = 1): EvaluationResults
+    {
+        if ($reference !== '') {
+            throw new \LogicException('Token limit evaluator takes only output text as argument');
+        }
+        if ($n !== 1) {
+            throw new \LogicException("Token limit evaluator doesn't support N-grams");
+        }
+        if ($this->tokenLimit === 0) {
+            throw new \LogicException('use TokenLimitEvaluator::setTokenLimit to specify token limit');
+        }
+
+        $provider = new EncoderProvider();
+        $encoder = $provider->get($this->provider); // @phpstan-ignore-line
+        $tokens = $encoder->encode($candidate);
+        $numTokens = count($tokens);
+
+        $result = (int) ($numTokens < $this->tokenLimit);
+
+        return new EvaluationResults(
+            'Token limit evaluator',
+            [
+                'score' => $result,
+                'error' => $result === 0 ? "Generated {$numTokens} tokens is grater than limit of {$this->tokenLimit}" : '',
+            ]
+        );
+    }
+
+    public function evaluateMessages(array $messages, array $references = [], int $n = 1): EvaluationResults
+    {
+        if ($references !== []) {
+            throw new \LogicException('Token limit evaluator takes only output texts as argument');
+        }
+        if ($n !== 1) {
+            throw new \LogicException("Token limit evaluator doesn't support N-grams");
+        }
+        $filteredMessages = $this->filterAssistantMessages($messages);
+        $resultsAll = [];
+        foreach ($filteredMessages as $filteredMessage) {
+            $resultsSingle = $this->evaluateText($filteredMessage);
+            $resultsAll[] = $resultsSingle->getResults()['score'];
+        }
+
+        return new EvaluationResults(
+            'Token limit evaluator',
+            $resultsAll
+        );
+    }
+
+    public function setProvider(string $provider): self
+    {
+        $this->provider = $provider;
+
+        return $this;
+    }
+
+    public function setTokenLimit(int $tokenLimit): self
+    {
+        $this->tokenLimit = $tokenLimit;
+
+        return $this;
+    }
+}

--- a/src/Evaluation/Output/WordLimitEvaluator.php
+++ b/src/Evaluation/Output/WordLimitEvaluator.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace LLPhant\Evaluation\Output;
+
+use LLPhant\Evaluation\AbstractEvaluator;
+use LLPhant\Evaluation\EvaluationResults;
+
+class WordLimitEvaluator extends AbstractEvaluator
+{
+    private int $wordLimit = 0;
+
+    public function evaluateText(string $candidate, string $reference = '', int $n = 1): EvaluationResults
+    {
+        if ($reference !== '') {
+            throw new \LogicException('Word limit evaluator takes only output text as argument');
+        }
+        if ($n !== 1) {
+            throw new \LogicException("Word limit evaluator doesn't support N-grams");
+        }
+        if ($this->wordLimit === 0) {
+            throw new \LogicException('use WordLimitEvaluator::setWordLimit to specify word limit');
+        }
+
+        $numWords = preg_match_all('/\p{L}+/u', $candidate, $_);
+        $result = (int) ($numWords < $this->wordLimit);
+
+        return new EvaluationResults(
+            'Word limit  evaluator',
+            [
+                'score' => $result,
+                'error' => $result === 0 ? "Generated {$numWords} words is grater than limit of {$this->wordLimit}" : '',
+            ]
+        );
+    }
+
+    public function evaluateMessages(array $messages, array $references = [], int $n = 1): EvaluationResults
+    {
+        if ($references !== []) {
+            throw new \LogicException('Word limit evaluator takes only output texts as argument');
+        }
+        if ($n !== 1) {
+            throw new \LogicException("Word limit evaluator doesn't support N-grams");
+        }
+        $filteredMessages = $this->filterAssistantMessages($messages);
+        $resultsAll = [];
+        foreach ($filteredMessages as $filteredMessage) {
+            $resultsSingle = $this->evaluateText($filteredMessage);
+            $resultsAll[] = $resultsSingle->getResults()['score'];
+        }
+
+        return new EvaluationResults(
+            'Word limit evaluator',
+            $resultsAll
+        );
+    }
+
+    public function setWordLimit(int $wordLimit): self
+    {
+        $this->wordLimit = $wordLimit;
+
+        return $this;
+    }
+}

--- a/tests/Unit/Evaluation/Output/TokenLimitEvaluatorTest.php
+++ b/tests/Unit/Evaluation/Output/TokenLimitEvaluatorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Evaluation\StringComparison;
+
+use LLPhant\Evaluation\Output\TokenLimitEvaluator;
+
+it('can evaluate token limit is exceeded', function (): void {
+    $output = "Lorizzle ipsum dolor sit fizzle, dizzle adipiscing fo shizzle. Nullam sapien own yo', mah nizzle volutpizzle, suscipizzle yippiyo, gravida vizzle, fo shizzle my nizzle. Pellentesque egizzle tortor. Fo shizzle erizzle. Rizzle at break it down dapibus pimpin' tempizzle shiz. Mauris gangster my shizz sizzle turpizzle. Vestibulum shut the shizzle up fizzle. Pellentesque eleifend rhoncizzle doggy. In hac that's the shizzle fo shizzle dictumst. Donec shizznit.";
+
+    $results = (new TokenLimitEvaluator())->setTokenLimit(100)->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 0,
+        'error' => 'Generated 137 tokens is grater than limit of 100',
+    ]);
+});

--- a/tests/Unit/Evaluation/Output/WordLimitEvaluatorTest.php
+++ b/tests/Unit/Evaluation/Output/WordLimitEvaluatorTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Evaluation\StringComparison;
+
+use LLPhant\Evaluation\Output\WordLimitEvaluator;
+
+it('can evaluate word limit is exceeded', function (): void {
+    $output = "Lorizzle ipsum dolor sit fizzle, dizzle adipiscing fo shizzle. Nullam sapien own yo', mah nizzle volutpizzle, suscipizzle yippiyo, gravida vizzle, fo shizzle my nizzle. Pellentesque egizzle tortor. Fo shizzle erizzle. Rizzle at break it down dapibus pimpin' tempizzle shiz. Mauris gangster my shizz sizzle turpizzle. Vestibulum shut the shizzle up fizzle. Pellentesque eleifend rhoncizzle doggy. In hac that's the shizzle fo shizzle dictumst. Donec shizznit.";
+
+    $results = (new WordLimitEvaluator())->setWordLimit(50)->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 0,
+        'error' => 'Generated 66 words is grater than limit of 50',
+    ]);
+});


### PR DESCRIPTION
Introduce Token limit evaluator and word limit evaluator.
These classes can be used as standalone evaluators or as guardrails to control budget and avoid exceeding it.
I didn't add README examples yet to avoid conflicts with my other PR that introduces new evaluator.
