### PR TITLE
introduce regex pattern based evaluators

### DIFF
--- a/src/Evaluation/Output/ShouldMatchRegexPatternEvaluator.php
+++ b/src/Evaluation/Output/ShouldMatchRegexPatternEvaluator.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace LLPhant\Evaluation\Output;
+
+use LLPhant\Evaluation\AbstractEvaluator;
+use LLPhant\Evaluation\EvaluationResults;
+
+class ShouldMatchRegexPatternEvaluator extends AbstractEvaluator
+{
+    protected string $regexPattern = '';
+
+    public function evaluateText(string $candidate, string $reference = '', int $n = 1): EvaluationResults
+    {
+        if ($reference !== '') {
+            throw new \LogicException('Regex pattern evaluator takes only output text as argument');
+        }
+        if ($n !== 1) {
+            throw new \LogicException("Regex pattern evaluator doesn't support N-grams");
+        }
+        if ($this->regexPattern === '') {
+            throw new \LogicException('specify regex pattern');
+        }
+
+        $out = preg_match($this->regexPattern, $candidate, $_);
+        $result = (int) ($out > 0);
+
+        return new EvaluationResults(
+            'Regex pattern should match evaluator',
+            [
+                'score' => $result,
+                'error' => $result !== 0 ? '' : "Regex pattern {$this->regexPattern} doesn't match text: {$candidate}.",
+            ]
+        );
+    }
+
+    public function evaluateMessages(array $messages, array $references = [], int $n = 1): EvaluationResults
+    {
+        if ($references !== []) {
+            throw new \LogicException('Regex pattern evaluator takes only output texts as argument');
+        }
+        if ($n !== 1) {
+            throw new \LogicException("Regex pattern evaluator doesn't support N-grams");
+        }
+        $filteredMessages = $this->filterAssistantMessages($messages);
+        $resultsAll = [];
+        foreach ($filteredMessages as $filteredMessage) {
+            $resultsSingle = $this->evaluateText($filteredMessage);
+            $resultsAll[] = $resultsSingle->getResults()['score'];
+        }
+
+        return new EvaluationResults(
+            'Regex pattern evaluator',
+            $resultsAll
+        );
+    }
+
+    public function setRegexPattern(string $regexPattern): ShouldMatchRegexPatternEvaluator
+    {
+        $this->regexPattern = $regexPattern;
+
+        return $this;
+    }
+}

--- a/src/Evaluation/Output/ShouldNotMatchRegexPatternEvaluator.php
+++ b/src/Evaluation/Output/ShouldNotMatchRegexPatternEvaluator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LLPhant\Evaluation\Output;
+
+use LLPhant\Evaluation\EvaluationResults;
+
+class ShouldNotMatchRegexPatternEvaluator extends ShouldMatchRegexPatternEvaluator
+{
+    public function evaluateText(string $candidate, string $reference = '', int $n = 1): EvaluationResults
+    {
+        $out = parent::evaluateText($candidate, $reference, $n);
+        $results = $out->getResults();
+
+        return new EvaluationResults(
+            'Regex pattern should not match evaluator',
+            [
+                'score' => (int) ! $results['score'],
+                'error' => $results['score'] ? "Regex pattern {$this->regexPattern} matches text: {$candidate}." : '',
+            ]
+        );
+    }
+}

--- a/tests/Unit/Evaluation/Output/ShouldMatchRegexPatternEvaluatorTest.php
+++ b/tests/Unit/Evaluation/Output/ShouldMatchRegexPatternEvaluatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Evaluation\StringComparison;
+
+use LLPhant\Evaluation\Output\ShouldMatchRegexPatternEvaluator;
+
+it('can evaluate regex pattern match a text', function (): void {
+    $output = 'once upon a time pink elephant jumped over a table';
+
+    $results = (new ShouldMatchRegexPatternEvaluator())->setRegexPattern('/pink elephant/')->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 1,
+        'error' => '',
+    ]);
+});
+
+it("can evaluate regex pattern doesn't match a text", function (): void {
+    $output = 'once upon a time pink elephant jumped over a table';
+
+    $results = (new ShouldMatchRegexPatternEvaluator())->setRegexPattern('/pink LLPhant/')->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 0,
+        'error' => "Regex pattern /pink LLPhant/ doesn't match text: once upon a time pink elephant jumped over a table.",
+    ]);
+});

--- a/tests/Unit/Evaluation/Output/ShouldNotMatchRegexPatternEvaluatorTest.php
+++ b/tests/Unit/Evaluation/Output/ShouldNotMatchRegexPatternEvaluatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Evaluation\StringComparison;
+
+use LLPhant\Evaluation\Output\ShouldNotMatchRegexPatternEvaluator;
+
+it('can evaluate regex pattern match a text', function (): void {
+    $output = 'once upon a time pink elephant jumped over a table';
+
+    $results = (new ShouldNotMatchRegexPatternEvaluator())->setRegexPattern('/pink elephant/')->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 0,
+        'error' => 'Regex pattern /pink elephant/ matches text: once upon a time pink elephant jumped over a table.',
+    ]);
+});
+
+it("can evaluate regex pattern doesn't match a text", function (): void {
+    $output = 'once upon a time pink elephant jumped over a table';
+
+    $results = (new ShouldNotMatchRegexPatternEvaluator())->setRegexPattern('/pink LLPhant/')->evaluateText($output);
+
+    expect($results->getResults())->toBe([
+        'score' => 1,
+        'error' => '',
+    ]);
+});


### PR DESCRIPTION
Introduce regex pattern  evaluators.
These classes can be used as standalone evaluators or as guardrails to check for appearance of expected pattern in output or avoid appearance of unexpected patterns in generated answers.
I didn't add README examples yet to avoid conflicts with my other PRs that introduce new evaluators.