### PR TITLE
psr/http-message ^1.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php-http/multipart-stream-builder": "^1.4.2",
         "phpoffice/phpword": "^1.4.0",
         "psr/http-client": "^1.0.3",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/log": "^3.0",
         "smalot/pdfparser": "^2.11",
         "yethee/tiktoken": "^0.10.0"


### PR DESCRIPTION
A lot of packages still depend on v1 of psr/http-message (especially `react` related packages).

The only difference between v1 and v2 is return type hints were added (https://github.com/php-fig/http-message/releases/tag/2.0). None of the psr/http-message classes are actually implemented in this package so it makes no difference.