### PR TITLE
fix(OpenAI): handle HTTP errors to prevent response parsing failures

### DIFF
--- a/src/Chat/MistralAIChat.php
+++ b/src/Chat/MistralAIChat.php
@@ -39,6 +39,7 @@ class MistralAIChat extends OpenAIChat
     {
         $stack = HandlerStack::create();
         $stack->push(MistralJsonResponseModifier::createResponseModifier());
+        $stack->push(OpenAIResponseErrorsProcessor::createResponseModifier());
 
         return new GuzzleClient([
             'handler' => $stack,

--- a/src/Chat/OpenAIResponseErrorsProcessor.php
+++ b/src/Chat/OpenAIResponseErrorsProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace LLPhant\Chat;
+
+use GuzzleHttp\Middleware;
+use LLPhant\Exception\HttpException;
+use Psr\Http\Message\ResponseInterface;
+
+class OpenAIResponseErrorsProcessor
+{
+    public static function createResponseModifier(): callable
+    {
+        return Middleware::mapResponse(fn: self::getModifierFunction());
+    }
+
+    private static function getModifierFunction(): \Closure
+    {
+        return function (ResponseInterface $response): ResponseInterface {
+            $status = $response->getStatusCode();
+            if ($status < 200 || $status >= 300) {
+                throw new HttpException(
+                    message: sprintf(
+                        'HTTP error from OpenAI (%d): %s',
+                        $status,
+                        $response->getBody()->getContents()
+                    ),
+                    code: $status
+                );
+            }
+
+            return $response;
+        };
+    }
+}


### PR DESCRIPTION
Problem:

The OpenAI client library was attempting to parse HTTP error responses as successful completions, causing fatal parsing errors when using OpenAI-compatible APIs (e.g., Gemini, Mistral) with invalid API tokens or model names.

Fix:

Added Guzzle middleware to throw HttpException for non-2xx HTTP responses before the OpenAI client attempts parsing, ensuring clear error messages instead of cryptic array access failures.

Reproduction:

```php
include_once __DIR__ . '/vendor/autoload.php';
$config = new MistralAIConfig();
$config->apiKey = 'fake key';
$chat = new MistralAIChat($config);
$chat->generateText('Hello!');
```

Before fix:

```console
PHP Warning:  Undefined array key "choices" ...
PHP Fatal error:  Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, null given ...
```

After fix:

```console
PHP Fatal error:  Uncaught LLPhant\Exception\HttpException:
HTTP error from OpenAI (401): {"detail":"Unauthorized"}
```