### PR TITLE
feat: add Evolink as an OpenAI-compatible chat provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ You can set host names and keys for the various services involved in integration
 ```
 OPENAI_API_KEY
 ATLASCLOUD_API_KEY
+EVOLINK_API_KEY
 MISTRAL_API_KEY
 ANTHROPIC_API_KEY
 ASTRADB_ENDPOINT

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 We designed this framework to be as simple as possible, while still providing you with the tools you need to build powerful apps.
 It is compatible with Symfony and Laravel.
 
-We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/), [Ollama](https://ollama.ai/), [LM Studio](https://lmstudio.ai/), [Atlas Cloud](https://www.atlascloud.ai/docs) and services compatible with the OpenAI API such as [LocalAI](https://localai.io/).
+We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/), [Ollama](https://ollama.ai/), [LM Studio](https://lmstudio.ai/), [Atlas Cloud](https://www.atlascloud.ai/docs), [Evolink](https://evolink.ai/) and services compatible with the OpenAI API such as [LocalAI](https://localai.io/).
 Ollama that can be used to run LLM locally such as [Llama 2](https://llama.meta.com/).
 
 We want to thank few amazing projects that we use here or inspired us:

--- a/src/EvolinkConfig.php
+++ b/src/EvolinkConfig.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant;
+
+use OpenAI\Contracts\ClientContract;
+
+/**
+ * Evolink exposes an OpenAI-compatible chat API.
+ *
+ * @see https://docs.evolink.ai
+ *
+ * @phpstan-import-type ModelOptions from OpenAIConfig
+ */
+class EvolinkConfig extends OpenAIConfig
+{
+    /**
+     * @param  ModelOptions  $modelOptions
+     */
+    public function __construct(
+        ?string $apiKey = null,
+        string $url = 'https://direct.evolink.ai/v1',
+        ?string $model = null,
+        ?ClientContract $client = null,
+        array $modelOptions = [],
+    ) {
+        parent::__construct(
+            apiKey: $apiKey ?? Utility::readEnvironment('EVOLINK_API_KEY'),
+            url: $url,
+            model: $model ?? 'gpt-5.2',
+            client: $client,
+            modelOptions: $modelOptions,
+        );
+    }
+}

--- a/tests/Unit/Chat/EvolinkConfigTest.php
+++ b/tests/Unit/Chat/EvolinkConfigTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Chat;
+
+use LLPhant\EvolinkConfig;
+
+afterEach(function () {
+    putenv('EVOLINK_API_KEY');
+    unset($_ENV['EVOLINK_API_KEY'], $_SERVER['EVOLINK_API_KEY']);
+});
+
+it('uses evolink defaults', function () {
+    $config = new EvolinkConfig('test-key');
+
+    expect($config->apiKey)->toBe('test-key')
+        ->and($config->url)->toBe('https://direct.evolink.ai/v1')
+        ->and($config->model)->toBe('gpt-5.2');
+});
+
+it('reads api key from environment', function () {
+    putenv('EVOLINK_API_KEY=env-key');
+
+    $config = new EvolinkConfig();
+
+    expect($config->apiKey)->toBe('env-key');
+});
+
+it('allows overriding url, model and model options', function () {
+    $config = new EvolinkConfig(
+        apiKey: 'test-key',
+        url: 'https://custom.example/v1',
+        model: 'gemini-2.5-flash',
+        modelOptions: ['temperature' => 0.2]
+    );
+
+    expect($config->url)->toBe('https://custom.example/v1')
+        ->and($config->model)->toBe('gemini-2.5-flash')
+        ->and($config->modelOptions)->toBe(['temperature' => 0.2]);
+});


### PR DESCRIPTION
### Description

[Evolink](https://evolink.ai) exposes an **OpenAI-compatible chat API** at `https://direct.evolink.ai/v1`, so it slots into LLPhant the same way [Atlas Cloud](https://github.com/LLPhant/LLPhant/blob/main/src/AtlasCloudConfig.php) does: a small `OpenAIConfig` subclass reused by the existing `OpenAIChat` client — no new chat class needed.

### Changes
- **`src/EvolinkConfig.php`** — `EvolinkConfig extends OpenAIConfig`; defaults the base URL to `https://direct.evolink.ai/v1`, reads the `EVOLINK_API_KEY` env var, and defaults the model to `gpt-5.2`. `url`, `model` and `modelOptions` remain overridable.
- **`tests/Unit/Chat/EvolinkConfigTest.php`** — no-network unit tests covering defaults, env-var resolution, and overrides (mirrors `AtlasCloudConfigTest`).
- **`README.md`** — lists Evolink among the supported LLM providers.
- **`CONTRIBUTING.md`** — documents the `EVOLINK_API_KEY` integration-test env var.

### Usage
```php
use LLPhant\Chat\OpenAIChat;
use LLPhant\EvolinkConfig;

// EVOLINK_API_KEY read from the environment; model defaults to gpt-5.2
$chat = new OpenAIChat(new EvolinkConfig());
$response = $chat->generateText('what is one + one ?');

// or pick a specific model
$chat = new OpenAIChat(new EvolinkConfig(model: 'gemini-2.5-flash'));
```

### Testing
Local run against this branch (PHP 8.5):
- `pint --test` (lint) — **pass**
- `phpstan` (`composer test:types`) — **No errors**
- type coverage (`--min=100`) — `src/EvolinkConfig.php` 100%, total 100%
- unit suite (`composer test:unit`) — **199 passed**, including the 3 new `EvolinkConfigTest` cases

A real end-to-end call through `OpenAIChat(new EvolinkConfig())` against the live Evolink endpoint is posted as a comment below.

### What is the purpose of this pull request?
- [x] New Feature