### PR TITLE
feat(orcarouter): add OrcaRouterConfig for the OpenAI-compatible gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 We designed this framework to be as simple as possible, while still providing you with the tools you need to build powerful apps.
 It is compatible with Symfony and Laravel.
 
-We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/), [Ollama](https://ollama.ai/), [LM Studio](https://lmstudio.ai/), [Atlas Cloud](https://www.atlascloud.ai/docs) and services compatible with the OpenAI API such as [LocalAI](https://localai.io/).
+We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/), [Ollama](https://ollama.ai/), [LM Studio](https://lmstudio.ai/), [Atlas Cloud](https://www.atlascloud.ai/docs), [OrcaRouter](https://www.orcarouter.ai) and services compatible with the OpenAI API such as [LocalAI](https://localai.io/).
 Ollama that can be used to run LLM locally such as [Llama 2](https://llama.meta.com/).
 
 ## Atlas Cloud
@@ -26,6 +26,19 @@ public Text model list include:
 - `deepseek-ai/deepseek-v4-pro`
 - `google/gemini-3.5-flash`
 - `zai-org/glm-4.7`
+
+## OrcaRouter
+
+LLPhant's `OrcaRouterConfig` targets the OpenAI-compatible OrcaRouter endpoint
+at `https://api.orcarouter.ai/v1` with the fully namespaced chat model
+`openai/gpt-4o-mini`.
+
+The configuration also accepts any OrcaRouter model slug via the optional
+`ORCAROUTER_MODEL` environment variable. Examples include:
+
+- `openai/gpt-4o-mini`
+- `openai/gpt-4o`
+- `deepseek/deepseek-v4-flash-0731`
 
 We want to thank few amazing projects that we use here or inspired us:
 

--- a/src/OrcaRouterConfig.php
+++ b/src/OrcaRouterConfig.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant;
+
+use OpenAI\Contracts\ClientContract;
+
+/**
+ * OrcaRouter exposes an OpenAI-compatible chat API.
+ *
+ * @see https://www.orcarouter.ai
+ *
+ * @phpstan-import-type ModelOptions from OpenAIConfig
+ */
+class OrcaRouterConfig extends OpenAIConfig
+{
+    /**
+     * @param  ModelOptions  $modelOptions
+     */
+    public function __construct(
+        ?string $apiKey = null,
+        string $url = 'https://api.orcarouter.ai/v1',
+        ?string $model = null,
+        ?ClientContract $client = null,
+        array $modelOptions = [],
+    ) {
+        parent::__construct(
+            apiKey: $apiKey ?? Utility::readEnvironment('ORCAROUTER_API_KEY'),
+            url: $url,
+            model: $model ?? Utility::readEnvironment('ORCAROUTER_MODEL', 'openai/gpt-4o-mini'),
+            client: $client,
+            modelOptions: $modelOptions,
+        );
+    }
+}

--- a/tests/Unit/Chat/OrcaRouterConfigTest.php
+++ b/tests/Unit/Chat/OrcaRouterConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Chat;
+
+use LLPhant\OrcaRouterConfig;
+
+afterEach(function () {
+    putenv('ORCAROUTER_API_KEY');
+    putenv('ORCAROUTER_MODEL');
+    unset(
+        $_ENV['ORCAROUTER_API_KEY'],
+        $_ENV['ORCAROUTER_MODEL'],
+        $_SERVER['ORCAROUTER_API_KEY'],
+        $_SERVER['ORCAROUTER_MODEL']
+    );
+});
+
+it('uses orcarouter defaults', function () {
+    $config = new OrcaRouterConfig('test-key');
+
+    expect($config->apiKey)->toBe('test-key')
+        ->and($config->url)->toBe('https://api.orcarouter.ai/v1')
+        ->and($config->model)->toBe('openai/gpt-4o-mini');
+});
+
+it('reads api key from environment', function () {
+    putenv('ORCAROUTER_API_KEY=env-key');
+
+    $config = new OrcaRouterConfig();
+
+    expect($config->apiKey)->toBe('env-key');
+});
+
+it('reads model from environment', function () {
+    putenv('ORCAROUTER_MODEL=deepseek/deepseek-v4-flash-0731');
+
+    $config = new OrcaRouterConfig('test-key');
+
+    expect($config->model)->toBe('deepseek/deepseek-v4-flash-0731');
+});
+
+it('falls back to the default model when ORCAROUTER_MODEL is set but empty', function () {
+    putenv('ORCAROUTER_MODEL=');
+
+    $config = new OrcaRouterConfig('test-key');
+
+    expect($config->model)->toBe('openai/gpt-4o-mini');
+});
+
+it('allows overriding url, model and model options', function () {
+    $config = new OrcaRouterConfig(
+        apiKey: 'test-key',
+        url: 'https://custom.example/v1',
+        model: 'openai/gpt-4o',
+        modelOptions: ['temperature' => 0.2]
+    );
+
+    expect($config->url)->toBe('https://custom.example/v1')
+        ->and($config->model)->toBe('openai/gpt-4o')
+        ->and($config->modelOptions)->toBe(['temperature' => 0.2]);
+});


### PR DESCRIPTION
## Add `OrcaRouterConfig` for the OrcaRouter OpenAI-compatible gateway

This adds a named `OrcaRouterConfig` mirroring the existing `AtlasCloudConfig`, so LLPhant can talk to [OrcaRouter](https://www.orcarouter.ai) — an OpenAI-compatible gateway at `https://api.orcarouter.ai/v1` that serves fully namespaced model ids (`openai/gpt-4o-mini`, `deepseek/deepseek-v4-flash-0731`, …). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- **`src/OrcaRouterConfig.php`** — new `OrcaRouterConfig extends OpenAIConfig`, defaulting to `https://api.orcarouter.ai/v1` and the namespaced chat model `openai/gpt-4o-mini`; reads `ORCAROUTER_API_KEY` and an optional `ORCAROUTER_MODEL` override, exactly like `AtlasCloudConfig`.
- **`tests/Unit/Chat/OrcaRouterConfigTest.php`** — mirrors the `AtlasCloudConfigTest` suite (defaults, env key/model, empty-env fallback, full override).
- **`README.md`** — lists OrcaRouter in the supported-providers line and adds a short "OrcaRouter" section.

### Usage

```php
$chat = new OpenAIChat(new OrcaRouterConfig());
// or
putenv('ORCAROUTER_API_KEY=sk-orca-...');
$chat = new OpenAIChat(new OrcaRouterConfig());
```

Model ids are namespaced, e.g. `openai/gpt-4o-mini`, `openai/gpt-4o`, `deepseek/deepseek-v4-flash-0731` — set any of them via `ORCAROUTER_MODEL` or the `model` argument.

### Verification

- `composer test:lint` — Pint: 277 files PASS
- `composer test:types` — PHPStan: No errors
- `composer test:type-coverage` — 100.0 % type coverage
- `composer test:unit` — 217 passed; the only failure (`FileDataReaderTest`) is a pre-existing Windows CRLF line-ending issue that reproduces on pristine `main`
- `tests/Unit/Chat/OrcaRouterConfigTest.php` — 5 passed
- L3 live test: `OrcaRouterConfig` → `OpenAIChat::generateChat()` → `https://api.orcarouter.ai/v1` with `openai/gpt-4o-mini` returned `OK`

I'm an engineer on the OrcaRouter team.
