### PR TITLE
Add LlmmanConfig for using llmman through the Ollama classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 We designed this framework to be as simple as possible, while still providing you with the tools you need to build powerful apps.
 It is compatible with Symfony and Laravel.
 
-We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/), [Ollama](https://ollama.ai/), [LM Studio](https://lmstudio.ai/), [Atlas Cloud](https://www.atlascloud.ai/docs) and services compatible with the OpenAI API such as [LocalAI](https://localai.io/).
+We are working to expand the support of different LLMs. Right now, we are supporting [OpenAI](https://openai.com/blog/openai-api), [Anthropic](https://www.anthropic.com/), [Mistral](https://mistral.ai/), [Ollama](https://ollama.ai/), [llmman](https://github.com/llmmanorg/llmman), [LM Studio](https://lmstudio.ai/), [Atlas Cloud](https://www.atlascloud.ai/docs) and services compatible with the OpenAI API such as [LocalAI](https://localai.io/).
 Ollama that can be used to run LLM locally such as [Llama 2](https://llama.meta.com/).
 
 ## Atlas Cloud

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -43,6 +43,13 @@ Comparison Table of all supported Language Models
      - ℹ️
      - ❌
      - ❌
+   * - llmman (via Ollama API)
+     - ✅
+     - ✅
+     - ℹ️
+     - ℹ️
+     - ❌
+     - ❌
    * - OpenAI
      - ✅
      - ✅

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -77,6 +77,23 @@ If you want to use Ollama, you can just specify the model to use using the ``Oll
     $config->model = 'llama2';
     $chat = new OllamaChat($config);
 
+llmman
+------
+
+`llmman <https://github.com/llmmanorg/llmman>`_ is a local model runner that serves the Ollama API
+on port 17434, so you can use it through ``OllamaChat`` and ``OllamaEmbeddingGenerator`` with
+``LlmmanConfig``.
+
+.. code-block:: php
+
+    $config = new LlmmanConfig();
+    $config->model = 'gemma4';
+    $chat = new OllamaChat($config);
+    $embeddings = new OllamaEmbeddingGenerator(new LlmmanConfig());
+
+The default base URL is ``http://localhost:17434/api/``; override the host with the
+``LLMMAN_HOST`` environment variable (``[host][:port]``).
+
 Anthropic
 ---------
 

--- a/src/LlmmanConfig.php
+++ b/src/LlmmanConfig.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LLPhant;
+
+/**
+ * OllamaConfig for llmman (https://github.com/llmmanorg/llmman), which serves the Ollama API
+ * on port 17434. The host can be overridden with LLMMAN_HOST ([host][:port]).
+ */
+class LlmmanConfig extends OllamaConfig
+{
+    public function __construct()
+    {
+        $host = Utility::readEnvironment('LLMMAN_HOST') ?? 'localhost:17434';
+        if (str_starts_with($host, ':')) {
+            $host = 'localhost'.$host;
+        }
+        if (! str_contains($host, ':')) {
+            $host .= ':17434';
+        }
+        $this->url = 'http://'.$host.'/api/';
+    }
+}

--- a/tests/Unit/Chat/LlmmanConfigTest.php
+++ b/tests/Unit/Chat/LlmmanConfigTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Chat;
+
+use LLPhant\Chat\OllamaChat;
+use LLPhant\LlmmanConfig;
+
+afterEach(function () {
+    putenv('LLMMAN_HOST');
+    unset($_ENV['LLMMAN_HOST'], $_SERVER['LLMMAN_HOST']);
+});
+
+it('uses llmman defaults', function () {
+    $config = new LlmmanConfig();
+
+    expect($config->url)->toBe('http://localhost:17434/api/');
+});
+
+it('reads host and port from LLMMAN_HOST', function () {
+    putenv('LLMMAN_HOST=llmman.local:8080');
+
+    expect((new LlmmanConfig())->url)->toBe('http://llmman.local:8080/api/');
+});
+
+it('completes a partial LLMMAN_HOST', function () {
+    putenv('LLMMAN_HOST=llmman.local');
+    expect((new LlmmanConfig())->url)->toBe('http://llmman.local:17434/api/');
+
+    putenv('LLMMAN_HOST=:8080');
+    expect((new LlmmanConfig())->url)->toBe('http://localhost:8080/api/');
+});
+
+it('can be used with OllamaChat', function () {
+    $config = new LlmmanConfig();
+    $config->model = 'gemma4';
+    $chat = new OllamaChat($config);
+
+    expect((string) $chat->client->getConfig('base_uri'))->toBe('http://localhost:17434/api/');
+});


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- `src/LlmmanConfig.php`: `LlmmanConfig extends OllamaConfig`, defaulting `url` to `http://localhost:17434/api/` and honouring `LLMMAN_HOST` (`[host][:port]`). Works with the existing `OllamaChat` / `OllamaEmbeddingGenerator`; no client code duplicated (same pattern as `AtlasCloudConfig` extending `OpenAIConfig`).
- `tests/Unit/Chat/LlmmanConfigTest.php`: Pest tests for the default URL, `LLMMAN_HOST` parsing and `OllamaChat` base URI.
- `docs/usage.rst`, `docs/features.rst`, `README.md`: llmman section next to Ollama, features-table row, provider-list mention.

**Testing:** `pest tests/Unit/Chat/LlmmanConfigTest.php`, `pint --test`, `phpstan` (level 8) and `php -l` on the new files pass inside a `composer:2` container.

> AI-assisted, reviewed before submitting.
